### PR TITLE
Skip ignorable whitespace when reading simple elements.

### DIFF
--- a/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlReader.kt
+++ b/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlReader.kt
@@ -278,6 +278,7 @@ fun XmlReader.readSimpleElement(): String {
         while ((t.next()) !== EventType.END_ELEMENT) {
             when (t.eventType) {
                 EventType.COMMENT,
+                EventType.IGNORABLE_WHITESPACE,
                 EventType.PROCESSING_INSTRUCTION -> {
                 }
                 EventType.TEXT,


### PR DESCRIPTION
Prior to this patch, when parsing an XML tag for a field marked
`@XmlElement(true)` with XML like:

```xml
<tag>
Text content
</tag>
```

The parser would fail due to the unexpected IGNORABLE_WHITESPACE in the
JVM. (JS seemed to handle it without issue even without this patch).

This patch ignores the ignorable whitespace.