### PR TITLE
Fix automatic module name

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -52,8 +52,6 @@ val argJvmDefault: String by project
 
 val androidAttribute = Attribute.of("net.devrieze.android", Boolean::class.javaObjectType)
 
-val moduleName = "net.devrieze.xmlutil.core"
-
 kotlin {
     explicitApi()
 
@@ -84,7 +82,7 @@ kotlin {
                 cleanTestTask.dependsOn(tasks.getByName("clean${target.name[0].toUpperCase()}${target.name.substring(1)}Test"))
                 tasks.named<Jar>("jvmJar") {
                     manifest {
-                        attributes("Automatic-Module-Name" to moduleName)
+                        attributes("Automatic-Module-Name" to "net.devrieze.xmlutil.core")
                     }
                 }
             }

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -57,9 +57,6 @@ val argJvmDefault: String by project
 
 val androidAttribute = Attribute.of("net.devrieze.android", Boolean::class.javaObjectType)
 
-val moduleName = "net.devrieze.xmlutil.serialization"
-
-
 kotlin {
     explicitApi()
     targets {
@@ -78,7 +75,7 @@ kotlin {
                 }
                 tasks.named<Jar>("jvmJar") {
                     manifest {
-                        attributes("Automatic-Module-Name" to moduleName)
+                        attributes("Automatic-Module-Name" to "net.devrieze.xmlutil.serialization")
                     }
                 }
             }

--- a/xmlserializable/build.gradle.kts
+++ b/xmlserializable/build.gradle.kts
@@ -56,8 +56,6 @@ val argJvmDefault: String by project
 val androidAttribute = Attribute.of("net.devrieze.android", Boolean::class.javaObjectType)
 val environmentAttr = TARGET_JVM_ENVIRONMENT_ATTRIBUTE
 
-val moduleName = "net.devrieze.xmlutil.xmlserializable"
-
 val testTask = tasks.create("test") {
     group = "verification"
 }
@@ -87,7 +85,7 @@ kotlin {
                 cleanTestTask.dependsOn(tasks.getByName("clean${target.name[0].toUpperCase()}${target.name.substring(1)}Test"))
                 tasks.named<Jar>("jvmJar") {
                     manifest {
-                        attributes("Automatic-Module-Name" to moduleName)
+                        attributes("Automatic-Module-Name" to "net.devrieze.xmlutil.xmlserializable")
                     }
                 }
             }


### PR DESCRIPTION
`moduleName` is a property inside `KotlinCompilation` which wins the resolution. This causes `Automatic-Module-Name` inside manifest to have a name of compilation, such as `xmlutil-serialization_woodstoxTest`. Inlining value fixes this issue.

Probably, a better solution would be to move this block from `compilations.all {}` to `jvm {}` scope. But I'm not sure if it can cause any unwanted side effects for the build.