### PR TITLE
Add ignorable whitespace test for xmlreader

### DIFF
--- a/core/src/commonTest/kotlin/nl/adaptivity/xmlutil/TestXmlReader.kt
+++ b/core/src/commonTest/kotlin/nl/adaptivity/xmlutil/TestXmlReader.kt
@@ -85,4 +85,23 @@ class TestXmlReader {
         assertEquals(inner, frag.contentString.replace(" />", "/>"))
         assertEquals(emptyList(), frag.namespaces.toList())
     }
+
+    @Test
+    fun testIgnorableWhitespace() {
+        val reader = XmlStreaming.newReader(
+            """
+            <root xmlns="foo">
+                <ns2:bar xmlns:ns2="bar"/>
+            </root>
+            """.trimIndent()
+        )
+
+        run {
+            var event = reader.next()
+            if (event == EventType.START_DOCUMENT) event = reader.next()
+            assertEquals(EventType.START_ELEMENT, event)
+        }
+
+        assertEquals(EventType.IGNORABLE_WHITESPACE, reader.next())
+    }
 }


### PR DESCRIPTION
Newline characters should be detected as IGNORABLE_WHITESPACE event type in between starting elements.
This test is only passing on jvm target.