### PR TITLE
Fix localName resolve bug in XmlBufferedReader

### DIFF
--- a/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlBufferedReaderBase.kt
+++ b/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlBufferedReaderBase.kt
@@ -56,6 +56,7 @@ public abstract class XmlBufferedReaderBase(private val delegate: XmlReader) : X
 
     override val localName: String
         get() = when (current?.eventType) {
+            EventType.ENTITY_REF -> (current as EntityRefEvent).localName
             EventType.ATTRIBUTE -> (current as Attribute).localName
             EventType.START_ELEMENT -> (current as StartElementEvent).localName
             EventType.END_ELEMENT -> (current as EndElementEvent).localName

--- a/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlBufferedReaderBase.kt
+++ b/core/src/commonMain/kotlin/nl/adaptivity/xmlutil/XmlBufferedReaderBase.kt
@@ -60,7 +60,7 @@ public abstract class XmlBufferedReaderBase(private val delegate: XmlReader) : X
             EventType.START_ELEMENT -> (current as StartElementEvent).localName
             EventType.END_ELEMENT -> (current as EndElementEvent).localName
             else -> throw XmlException(
-                "Attribute not defined here: namespaceUri"
+                "Attribute not defined here: localName"
             )
         }
 
@@ -69,7 +69,7 @@ public abstract class XmlBufferedReaderBase(private val delegate: XmlReader) : X
             EventType.ATTRIBUTE -> (current as Attribute).prefix
             EventType.START_ELEMENT -> (current as StartElementEvent).prefix
             EventType.END_ELEMENT -> (current as EndElementEvent).prefix
-            else -> throw XmlException("Attribute not defined here: namespaceUri")
+            else -> throw XmlException("Attribute not defined here: prefix")
         }
 
     override val depth: Int

--- a/serialization/src/commonTest/kotlin/nl/adaptivity/xml/serialization/ValueContainerAlternativeSerializer.kt
+++ b/serialization/src/commonTest/kotlin/nl/adaptivity/xml/serialization/ValueContainerAlternativeSerializer.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021.
+ *
+ * This file is part of xmlutil.
+ *
+ * This file is licenced to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You should have received a copy of the license with the source distribution.
+ * Alternatively, you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package nl.adaptivity.xml.serialization
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+import kotlinx.serialization.serializer
+import nl.adaptivity.xmlutil.*
+import nl.adaptivity.xmlutil.serialization.XML
+
+object CompatValueContainerSerializer : ValueContainerSerializer() {
+    override fun delegateFormat(decoder: Decoder) = (decoder as XML.XmlInput).delegateFormat()
+    override fun delegateFormat(encoder: Encoder) = (encoder as XML.XmlOutput).delegateFormat()
+}
+
+abstract class ValueContainerSerializer : KSerializer<ValueContainerAlternativeTest.ValueContainer> {
+
+    private val elementSerializer = serializer<ValueContainerAlternativeTest.InnerValueContainer>()
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("valueContainer") {
+        element("innerValueContainer", elementSerializer.descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): ValueContainerAlternativeTest.ValueContainer {
+        return if (decoder is XML.XmlInput) {
+            deserializeContainer(decoder, decoder.input)
+        } else {
+            val data = decoder.decodeStructure(descriptor) {
+                decodeSerializableElement(descriptor, 0, elementSerializer)
+            }
+            ValueContainerAlternativeTest.ValueContainer(data)
+        }
+    }
+
+    private fun deserializeContainer(
+        decoder: Decoder,
+        reader: XmlReader
+    ): ValueContainerAlternativeTest.ValueContainer {
+        val xml = delegateFormat(decoder)
+
+        var innerValueContainer: ValueContainerAlternativeTest.InnerValueContainer =
+            ValueContainerAlternativeTest.InnerValueContainer("")
+
+        decoder.decodeStructure(descriptor) {
+
+            while (reader.next() != EventType.END_ELEMENT) {
+                when (reader.eventType) {
+                    EventType.COMMENT,
+                    EventType.IGNORABLE_WHITESPACE,
+                    EventType.ENTITY_REF,
+                    EventType.TEXT -> {
+                    }
+                    EventType.START_ELEMENT -> {
+                        if (reader.localName != "innerValueContainer") {
+                            reader.skipElement()
+                        } else {
+                            innerValueContainer = xml.decodeFromReader(serializer(), reader)
+                        }
+                    }
+                    else ->
+                        throw XmlException("Unexpected tag content")
+                }
+            }
+        }
+
+        return ValueContainerAlternativeTest.ValueContainer(innerValueContainer)
+    }
+
+    override fun serialize(encoder: Encoder, value: ValueContainerAlternativeTest.ValueContainer) {
+        if (encoder is XML.XmlOutput) {
+            return serializeContainer(encoder, encoder.target, value.inner)
+        } else {
+            encoder.encodeStructure(descriptor) {
+                encodeSerializableElement(descriptor, 0, elementSerializer, value.inner)
+            }
+        }
+    }
+
+    private fun serializeContainer(
+        encoder: Encoder,
+        target: XmlWriter,
+        data: ValueContainerAlternativeTest.InnerValueContainer
+    ) {
+        val xml = delegateFormat(encoder)
+        encoder.encodeStructure(descriptor) {
+            xml.encodeToWriter(target, elementSerializer, data)
+        }
+    }
+
+    abstract fun delegateFormat(decoder: Decoder): XML
+    abstract fun delegateFormat(encoder: Encoder): XML
+
+}

--- a/serialization/src/commonTest/kotlin/nl/adaptivity/xml/serialization/ValueContainerAlternativeTest.kt
+++ b/serialization/src/commonTest/kotlin/nl/adaptivity/xml/serialization/ValueContainerAlternativeTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021.
+ *
+ * This file is part of xmlutil.
+ *
+ * This file is licenced to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You should have received a copy of the license with the source distribution.
+ * Alternatively, you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package nl.adaptivity.xml.serialization
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.*
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+class ValueContainerAlternativeTest : PlatformXmlTestBase<ValueContainerAlternativeTest.ValueContainer>(
+    ValueContainer(InnerValueContainer("<foo&bar>")),
+    ValueContainer.serializer()
+) {
+    override val expectedXML: String =
+        "<valueContainer><innerValueContainer>&lt;foo&amp;bar></innerValueContainer></valueContainer>"
+
+    @Serializable(with = CompatValueContainerSerializer::class)
+    @XmlSerialName("valueContainer")
+    data class ValueContainer(val inner: InnerValueContainer)
+
+    @Serializable
+    @XmlSerialName("innerValueContainer")
+    data class InnerValueContainer(@XmlValue(true) val content: String)
+}


### PR DESCRIPTION
When using a custom serializer with predefined entities in the xml source (like "&amp;" or "&lt;") the XmlBufferedReader will crash when resolving the localName of an entity ref event. The following exception appears. This PR contains a fix for this and also a test to reproduce this issue. I also fixed the xml exception message as it was misleading.

```
nl.adaptivity.xmlutil.XmlException: Attribute not defined here: namespaceUri
	at kotlin.Throwable#<init>(Unknown Source)
	at kotlin.Exception#<init>(Unknown Source)
	at nl.adaptivity.xmlutil.core.impl.multiplatform.IOException#<init>(Unknown Source)
	at nl.adaptivity.xmlutil.XmlException#<init>(Unknown Source)
	at nl.adaptivity.xmlutil.XmlBufferedReaderBase#<get-localName>(Unknown Source)
	at nl.adaptivity.xmlutil.EventType.ENTITY_REF.createEvent#internal(Unknown Source)
	at nl.adaptivity.xmlutil.XmlEvent.Companion#from(Unknown Source)
	at nl.adaptivity.xmlutil.XmlBufferedReaderBase#doPeek(Unknown Source)
	at nl.adaptivity.xmlutil.XmlBufferedReaderBase#peek(Unknown Source)
	at nl.adaptivity.xmlutil.XmlBufferedReaderBase#hasNext(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XmlDecoderBase.TagDecoder#decodeElementIndex(Unknown Source)
	at nl.adaptivity.xml.serialization.ValueContainerAlternativeTest.InnerValueContainer.$serializer#deserialize(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XmlDecoderBase.XmlDecoder#decodeSerializableValue(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XML#decodeFromReader(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XML#decodeFromReader$default(Unknown Source)
	at nl.adaptivity.xml.serialization.ValueContainerSerializer.deserializeContainer#internal(Unknown Source)
	at nl.adaptivity.xml.serialization.ValueContainerSerializer#deserialize(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XmlDecoderBase.XmlDecoder#decodeSerializableValue(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XML#decodeFromReader(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XML#decodeFromReader$default(Unknown Source)
	at nl.adaptivity.xmlutil.serialization.XML#decodeFromString(Unknown Source)
	at nl.adaptivity.xml.serialization.XmlTestBase#testDeserializeXml(Unknown Source)
	at nl.adaptivity.xml.serialization.$ValueContainerAlternativeTest$test$0.$testDeserializeXml$FUNCTION_REFERENCE$507.invoke#internal(Unknown Source)
	at nl.adaptivity.xml.serialization.$ValueContainerAlternativeTest$test$0.$testDeserializeXml$FUNCTION_REFERENCE$507.$<bridge-UNNN>invoke(Unknown Source)
	at kotlin.native.internal.test.BaseClassSuite.TestCase#run(Unknown Source)
	at kotlin.native.internal.test.TestRunner.run#internal(Unknown Source)
	at kotlin.native.internal.test.TestRunner.runIteration#internal(Unknown Source)
	at kotlin.native.internal.test.TestRunner#run(Unknown Source)
	at kotlin.native.internal.test#testLauncherEntryPoint(Unknown Source)
	at kotlin.native.internal.test#main(Unknown Source)
	at <global>.Konan_start(Unknown Source)
	at <global>.Init_and_run_start(Unknown Source)
	at <global>.__libc_start_main(Unknown Source)
	at <global>.0x0(Unknown Source)
```