### PR TITLE
Make `null` the default encoding in various places

### DIFF
--- a/core/base/api/base.api
+++ b/core/base/api/base.api
@@ -635,6 +635,7 @@ public final class nl/adaptivity/xmlutil/XmlStreaming : nl/adaptivity/xmlutil/co
 	public fun newGenericReader (Ljava/io/Reader;)Lnl/adaptivity/xmlutil/XmlReader;
 	public fun newGenericReader (Ljava/lang/CharSequence;)Lnl/adaptivity/xmlutil/XmlReader;
 	public final fun newGenericReader (Ljava/lang/String;)Lnl/adaptivity/xmlutil/XmlReader;
+	public static synthetic fun newGenericReader$default (Lnl/adaptivity/xmlutil/XmlStreaming;Ljava/io/InputStream;Ljava/lang/String;ILjava/lang/Object;)Lnl/adaptivity/xmlutil/XmlReader;
 	public final fun newGenericWriter (Ljava/lang/Appendable;ZLnl/adaptivity/xmlutil/XmlDeclMode;)Lnl/adaptivity/xmlutil/core/KtXmlWriter;
 	public static synthetic fun newGenericWriter$default (Lnl/adaptivity/xmlutil/XmlStreaming;Ljava/lang/Appendable;ZLnl/adaptivity/xmlutil/XmlDeclMode;ILjava/lang/Object;)Lnl/adaptivity/xmlutil/core/KtXmlWriter;
 	public fun newReader (Ljava/io/InputStream;Ljava/lang/String;)Lnl/adaptivity/xmlutil/XmlReader;

--- a/core/base/src/androidMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.android.kt
+++ b/core/base/src/androidMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.android.kt
@@ -136,7 +136,7 @@ public actual object XmlStreaming : XmlStreamingJavaCommon(), IXmlStreaming {
     public fun newGenericReader(input: String): XmlReader =
         newGenericReader(StringReader(input))
 
-    public fun newGenericReader(inputStream: InputStream, encoding: String?): XmlReader =
+    public fun newGenericReader(inputStream: InputStream, encoding: String? = null): XmlReader =
         KtXmlReader(inputStream, encoding)
 
     public override fun newGenericReader(reader: Reader): XmlReader = KtXmlReader(reader)

--- a/core/base/src/androidMain/kotlin/nl/adaptivity/xmlutil/core/impl/BetterXmlSerializer.kt
+++ b/core/base/src/androidMain/kotlin/nl/adaptivity/xmlutil/core/impl/BetterXmlSerializer.kt
@@ -327,7 +327,7 @@ public class BetterXmlSerializer : XmlSerializer {
     }
 
     @Throws(IOException::class)
-    override fun setOutput(os: OutputStream?, encoding: String?) {
+    override fun setOutput(os: OutputStream?, encoding: String? = null) {
         if (os == null) {
             throw IllegalArgumentException()
         }

--- a/core/base/src/commonMain/kotlin/nl/adaptivity/xmlutil/core/KtXmlReader.kt
+++ b/core/base/src/commonMain/kotlin/nl/adaptivity/xmlutil/core/KtXmlReader.kt
@@ -29,7 +29,7 @@ import kotlin.jvm.JvmInline
 @ExperimentalXmlUtilApi
 public class KtXmlReader internal constructor(
     private val reader: Reader,
-    encoding: String?,
+    encoding: String? = null,
     public val relaxed: Boolean = false
 ) : XmlReader {
 

--- a/core/base/src/jvmMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.jvm.kt
+++ b/core/base/src/jvmMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.jvm.kt
@@ -188,7 +188,7 @@ public actual object XmlStreaming : XmlStreamingJavaCommon(), IXmlStreaming {
     public fun newGenericReader(input: String): XmlReader =
         newGenericReader(StringReader(input))
 
-    public fun newGenericReader(inputStream: InputStream, encoding: String?): XmlReader =
+    public fun newGenericReader(inputStream: InputStream, encoding: String? = null): XmlReader =
         KtXmlReader(inputStream, encoding)
 
     public override fun newGenericReader(reader: Reader): XmlReader = KtXmlReader(reader)

--- a/core/jdk/api/jdk.api
+++ b/core/jdk/api/jdk.api
@@ -1,5 +1,6 @@
 public final class nl/adaptivity/xmlutil/jdk/StAXReader : nl/adaptivity/xmlutil/XmlReader {
 	public fun <init> (Ljava/io/InputStream;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/io/InputStream;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/io/Reader;)V
 	public fun <init> (Ljavax/xml/stream/XMLStreamReader;)V
 	public fun <init> (Ljavax/xml/transform/Source;)V

--- a/core/jdk/src/main/kotlin/nl/adaptivity/xmlutil/jdk/StAXReader.kt
+++ b/core/jdk/src/main/kotlin/nl/adaptivity/xmlutil/jdk/StAXReader.kt
@@ -46,7 +46,7 @@ public class StAXReader(private val delegate: XMLStreamReader) : XmlReader {
     public constructor(reader: Reader) : this(safeInputFactory().createXMLStreamReader(reader))
 
     @Throws(XMLStreamException::class)
-    public constructor(inputStream: InputStream, encoding: String?) : this(
+    public constructor(inputStream: InputStream, encoding: String? = null) : this(
         safeInputFactory().createXMLStreamReader(
             inputStream,
             encoding

--- a/core/src/androidMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.android.kt
+++ b/core/src/androidMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.android.kt
@@ -157,7 +157,7 @@ public actual object XmlStreaming : XmlStreamingJavaCommon(), IXmlStreaming {
     public fun newGenericReader(input: String): XmlReader =
         newGenericReader(StringReader(input))
 
-    public fun newGenericReader(inputStream: InputStream, encoding: String?): XmlReader =
+    public fun newGenericReader(inputStream: InputStream, encoding: String? = null): XmlReader =
         KtXmlReader(inputStream, encoding)
 
     public override fun newGenericReader(reader: Reader): XmlReader = KtXmlReader(reader)

--- a/core/src/androidMain/kotlin/nl/adaptivity/xmlutil/core/impl/BetterXmlSerializer.kt
+++ b/core/src/androidMain/kotlin/nl/adaptivity/xmlutil/core/impl/BetterXmlSerializer.kt
@@ -336,7 +336,7 @@ public class BetterXmlSerializer : XmlSerializer {
     }
 
     @Throws(IOException::class)
-    override fun setOutput(os: OutputStream?, encoding: String?) {
+    override fun setOutput(os: OutputStream?, encoding: String? = null) {
         if (os == null) {
             throw IllegalArgumentException()
         }

--- a/core/src/jvmMain/kotlin/nl/adaptivity/xmlutil/StAXReader.kt
+++ b/core/src/jvmMain/kotlin/nl/adaptivity/xmlutil/StAXReader.kt
@@ -47,7 +47,7 @@ public class StAXReader(private val delegate: XMLStreamReader) : XmlReader {
     public constructor(reader: Reader) : this(safeInputFactory().createXMLStreamReader(reader))
 
     @Throws(XMLStreamException::class)
-    public constructor(inputStream: InputStream, encoding: String?) : this(
+    public constructor(inputStream: InputStream, encoding: String? = null) : this(
         safeInputFactory().createXMLStreamReader(
             inputStream,
             encoding

--- a/core/src/jvmMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.jvm.kt
+++ b/core/src/jvmMain/kotlin/nl/adaptivity/xmlutil/XmlStreaming.jvm.kt
@@ -191,7 +191,7 @@ public actual object XmlStreaming : XmlStreamingJavaCommon(), IXmlStreaming {
     public fun newGenericReader(input: String): XmlReader =
         newGenericReader(StringReader(input))
 
-    public fun newGenericReader(inputStream: InputStream, encoding: String?): XmlReader =
+    public fun newGenericReader(inputStream: InputStream, encoding: String? = null): XmlReader =
         KtXmlReader(inputStream, encoding)
 
     public override fun newGenericReader(reader: Reader): XmlReader = KtXmlReader(reader)


### PR DESCRIPTION
This usually cuases the implementation to auto-detect the encoding.