### PR TITLE
Add missing native targets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 apiVersion = "1.8"
 binaryValidator = "0.15.0-Beta.2"
-dateTime = "0.4.1"
+dateTime = "0.6.1"
 dokka = "1.9.20"
 javaVersion = "8"
 jmh = "0.7.2"

--- a/project-plugins/src/main/kotlin/net/devrieze/gradle/ext/nativeTargets.kt
+++ b/project-plugins/src/main/kotlin/net/devrieze/gradle/ext/nativeTargets.kt
@@ -214,6 +214,7 @@ fun Project.addNativeTargets(includeWasm: Boolean = true, includeWasi: Boolean =
                         iosSimulatorArm64()
                         iosX64()
 
+                        watchosDeviceArm64()
                         watchosSimulatorArm64()
                         watchosX64()
                         watchosArm32()
@@ -226,7 +227,15 @@ fun Project.addNativeTargets(includeWasm: Boolean = true, includeWasi: Boolean =
 
                     if (nativeState != NativeState.HOST || host == Host.Windows) {
                         logger.lifecycle("Adding Windows x64 target")
-                        mingwX64 { }
+                        mingwX64()
+                    }
+
+                    if (nativeState != NativeState.HOST) {
+                        logger.lifecycle("Adding Android native targets")
+                        androidNativeArm32()
+                        androidNativeArm64()
+                        androidNativeX86()
+                        androidNativeX64()
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/pdvrieze/xmlutil/issues/240
Hope that I've added `androidNative*` targets in a right place, as build setup is a bit hard to follow :(

Note: datetime updated is required, as androidNative targets are supported only from 0.6.0